### PR TITLE
Updates to how headers are proxied

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:alpine AS build-env
 RUN apk update && apk upgrade && \
     apk add --no-cache bash git openssh
-WORKDIR /app 
+WORKDIR /app
 ADD . .
 RUN go build -o main .
 

--- a/http-lambda-invoker.go
+++ b/http-lambda-invoker.go
@@ -62,15 +62,14 @@ func getConfig(key string) string {
 	}
 }
 
-func makeProxyHeaders(original_headers map[string][]string) proxyHeader {
-	var new_headers proxyHeader
-	new_headers = make(proxyHeader)
+func makeProxyHeaders(originalHeaders map[string][]string) proxyHeader {
+	var newHeaders = make(proxyHeader)
 
-	for header := range original_headers {
-		new_headers[header] = strings.Join(original_headers[header], "")
+	for header := range originalHeaders {
+		newHeaders[header] = strings.Join(originalHeaders[header], "")
 	}
 
-	return new_headers
+	return newHeaders
 }
 
 func handleError(w http.ResponseWriter, err error) {

--- a/http-lambda-invoker.go
+++ b/http-lambda-invoker.go
@@ -15,6 +15,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strings"
 )
 
 // LambdaClient enables mocking of the client for test purposes
@@ -22,10 +23,12 @@ type LambdaClient struct {
 	lambdaiface.LambdaAPI
 }
 
+type proxyHeader map[string]string
+
 // Parts of the request to send to Lambda.
 type makeProxyRequest struct {
 	Body              []byte              `json:"body"`
-	Headers           map[string][]string `json:"headers"`
+	Headers           proxyHeader					`json:"headers"`
 	HTTPMethod        string              `json:"httpMethod"`
 	Path              string              `json:"path"`
 	QueryStringParams map[string][]string `json:"queryStringParameters"`
@@ -57,6 +60,17 @@ func getConfig(key string) string {
 	default:
 		return ""
 	}
+}
+
+func makeProxyHeaders(original_headers map[string][]string) proxyHeader {
+	var new_headers proxyHeader
+	new_headers = make(proxyHeader)
+
+	for header := range original_headers {
+		new_headers[header] = strings.Join(original_headers[header], "")
+	}
+
+	return new_headers
 }
 
 func handleError(w http.ResponseWriter, err error) {
@@ -91,8 +105,11 @@ func (c *LambdaClient) invokeLambda(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Convert headers to appropriate ApiGateway format
+	proxyHeaders := makeProxyHeaders(r.Header)
+
 	// Get struct.
-	request := makeProxyRequest{body, r.Header, r.Method, r.URL.Path, r.URL.Query()}
+	request := makeProxyRequest{body, proxyHeaders, r.Method, r.URL.Path, r.URL.Query()}
 
 	// Marshal request.
 	payload, err := json.Marshal(request)

--- a/proxy-headers_test.go
+++ b/proxy-headers_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestHeaders(t *testing.T) {
+	var headers = map[string][]string{
+		"Accept":                    {"text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"},
+		"Accept-Encoding":           {"gzip, deflate, br"},
+		"Accept-Language":           {"en-US,en;q=0.9"},
+		"Cache-Control":             {"no-cache"},
+		"Connection":                {"keep-alive"},
+		"Pragma":                    {"no-cache"},
+		"Sec-Fetch-Dest":            {"document"},
+		"Sec-Fetch-Mode":            {"navigate"},
+		"Sec-Fetch-Site":            {"none"},
+		"Sec-Fetch-User":            {"?1"},
+		"Upgrade-Insecure-Requests": {"1"},
+		"User-Agent":                {"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.163 Safari/537.36"},
+	}
+
+	var expectedResult = map[string]string{
+		"Accept":                    "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+		"Accept-Encoding":           "gzip, deflate, br",
+		"Accept-Language":           "en-US,en;q=0.9",
+		"Cache-Control":             "no-cache",
+		"Connection":                "keep-alive",
+		"Pragma":                    "no-cache",
+		"Sec-Fetch-Dest":            "document",
+		"Sec-Fetch-Mode":            "navigate",
+		"Sec-Fetch-Site":            "none",
+		"Sec-Fetch-User":            "?1",
+		"Upgrade-Insecure-Requests": "1",
+		"User-Agent":                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.163 Safari/537.36",
+	}
+
+	var newHeaders = makeProxyHeaders(headers)
+
+	for header := range newHeaders {
+		if newHeaders[header] != expectedResult[header] {
+			t.Errorf("Parsed header %v did not match expected %v", newHeaders[header], expectedResult[header])
+		}
+	}
+}


### PR DESCRIPTION
For some reason the golang http library is processing the headers as a map of Arrays. This PR aims at converting the event headers from a map of Arrays to a map of strings. 