### PR TITLE
Fix string formatting issue

### DIFF
--- a/http-lambda-invoker.go
+++ b/http-lambda-invoker.go
@@ -143,7 +143,7 @@ func (c *LambdaClient) invokeLambda(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	// Write status code and body.
 	w.WriteHeader(response.StatusCode)
-	fmt.Fprintf(w, string(response.Body))
+	fmt.Fprint(w, string(response.Body))
 }
 
 // Start simple web server with configured port, sending all traffic to handler.


### PR DESCRIPTION
Using `Fprint `instead of `Fprintf`, as there is no string formatting going on, but some special character combinations in the input (like url-encoded "/" characters in the form of "%2F") might cause unexpected results, because they will be treated as string format specifiers.